### PR TITLE
fix(opencl):  修复`base58_encode`方法返回了错误的字符串

### DIFF
--- a/opencl/kernel.cl
+++ b/opencl/kernel.cl
@@ -5009,6 +5009,7 @@ static uchar *base58_encode(uchar *in, size_t *out_len) {
   in += total;
   in_len -= total;
   out += total;
+  size_t zero_length = total;
 
   // encoding
   size_t idx = 0;
@@ -5037,6 +5038,9 @@ static uchar *base58_encode(uchar *in, size_t *out_len) {
     out[c_idx] = alphabet[(uchar)out[c_idx]];
   }
   *out_len = total;
+  if (zero_length) {
+    out -= zero_length;
+  }
   return out;
 }
 


### PR DESCRIPTION
比如需要搜寻以 aa 为开头的地址, 版本代码会出现 1aa, 11aa 也会匹配的情况. 