### PR TITLE
Update docker command to mount gpu(s) to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Only works on Linux platforms with Nvidia GPUs. [Check this doc](https://docs.nv
 
 ```bash
 $ docker build -t sol_vanity_cl .
-$ docker run --rm -it sol_vanity_cl
+$ docker run --rm -it --gpus all sol_vanity_cl
 ```
 
 You will enter the container. The source code is located in the /app directory in the container, and all dependencies have been installed.


### PR DESCRIPTION
Docker does not mount the gpu(s) to the container by default, - so this flag makes that happen. 

p.s, from my testing, `--select-device` had to be passed in the container, else there'd be some error given about no device being found, however I did not test if this is the case on the host linux system. (did not encounter it at all on a mac btw)