### PR TITLE
Fix searcher.py compounding sleep times

### DIFF
--- a/core/searcher.py
+++ b/core/searcher.py
@@ -74,10 +74,15 @@ class Searcher:
             (self.setting.local_work_size,),
         )
         self.setting.increase_key32()
+        
+        # Calculate prev_time BEFORE sleep - only includes GPU work time
+        self.prev_time = time.time() - start_time
+        
         if self.prev_time is not None and self.is_nvidia:
             time.sleep(self.prev_time * 0.98)
+        
         cl.enqueue_copy(self.command_queue, self.output, self.memobj_output).wait()
-        self.prev_time = time.time() - start_time
+        
         if log_stats:
             logging.info(
                 f"GPU {self.display_index} Speed: {global_worker_size / ((time.time() - start_time) * 1e6):.2f} MH/s"


### PR DESCRIPTION
https://github.com/WincerChan/SolVanityCL/issues/45

The `find` method in `Searcher` was calculating `prev_time` after the sleep operation, causing each iteration's sleep duration to include the previous sleep time:

1st: 1s work → sleep 0.98s
2nd: 1s work + 0.98s sleep → sleep 1.94s
3rd: 1s work + 1.94s sleep → sleep 2.88s

This caused GPU performance to appear to drop from ~14 MH/s to ~7 MH/s and continue declining.

Fix: Move `prev_time` calculation before sleep so it only measures GPU work time, keeping sleep duration constant at 98% of actual work time. Results in console confirm consistent GPU speeds after the change.